### PR TITLE
Fix broken page. Updated iron:middleware-stack versions.

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -38,13 +38,13 @@ htmljs@1.0.4
 http@1.1.0
 id-map@1.0.3
 iron:controller@1.0.8
-iron:core@1.0.8
+iron:core@1.0.11
 iron:dynamic-template@1.0.8
 iron:layout@1.0.8
 iron:location@1.0.9
-iron:middleware-stack@1.0.9
+iron:middleware-stack@1.1.0
 iron:router@1.0.9
-iron:url@1.0.9
+iron:url@1.0.11
 jparker:crypto-core@0.1.0
 jparker:crypto-md5@0.1.1
 jparker:gravatar@0.3.1


### PR DESCRIPTION
Currently, the home page at jobs.ethercasts.com is broken on Chrome, showing a completely blank background. Updating iron:middleware-stack fixes the problem, as described [here](https://forums.meteor.com/t/solved-error-handler-with-name-u-already-exists/23910/11).
